### PR TITLE
Requirements should be fully listed in the setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     url="https://github.com/migueldvb/cine",
     packages=["cine"],
     install_requires=[
-        'numpy',
+        'numpy', 'scipy', 'pandas', 'astroquery'
     ],
     scripts=['bin/cine'],
     description="Calculate infrared pumping rates by solar radiation",


### PR DESCRIPTION
Right now the only requirement I see in ``setup.py`` is `numpy`, but the docs README says that  `astroquery`, `scipy`, and `pandas` are also required. This PR just adds those three in.